### PR TITLE
Point to cjs entrypoint from project main

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "sideEffects": false,
   "type": "module",
-  "main": "./index.js",
+  "main": "./dist/index.cjs",
   "module": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {


### PR DESCRIPTION
This fixes module imports on node, making `require('lib0')` work correctly.