### PR TITLE
Don’t register storage event listener in Node.js environments

### DIFF
--- a/broadcastchannel.js
+++ b/broadcastchannel.js
@@ -42,7 +42,9 @@ class LocalStoragePolyfill {
      * @type {null|function({data:ArrayBuffer}):void}
      */
     this.onmessage = null
-    addEventListener('storage', e => e.key === room && this.onmessage !== null && this.onmessage({ data: buffer.fromBase64(e.newValue || '') }))
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', e => e.key === room && this.onmessage !== null && this.onmessage({ data: buffer.fromBase64(e.newValue || '') }))
+    }
   }
 
   /**


### PR DESCRIPTION
### This PR
1. Checks if it’s running in a browser context.
2. Only then registers the `storage` event listener in the LocalStoragePolyfill.

Merging this PR would make y-websocket run in Node.js environments, see https://github.com/yjs/y-websocket/issues/51 https://github.com/yjs/y-websocket/issues/55

### Alternative solutions
1. It doesn’t make sense to use the LocalStoragePolyfill in Node.js environments at all. A check to load the Polyfill only in a browser context would probably work too.
2. Add for example `node-localstorage` to add support for localstorage to Node.js.

Let me know if you I can do anything to improve the PR. 💖

