### PR TITLE
Handle surrogate pairs in diff

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -39,18 +39,20 @@ import { equalityStrict } from './function.js'
  * @return {SimpleDiff<string>} The diff description.
  */
 export const simpleDiffString = (a, b) => {
+  const aArr = Array.from(a)
+  const bArr = Array.from(b)
   let left = 0 // number of same characters counting from left
   let right = 0 // number of same characters counting from right
-  while (left < a.length && left < b.length && a[left] === b[left]) {
+  while (left < aArr.length && left < bArr.length && aArr[left] === bArr[left]) {
     left++
   }
-  while (right + left < a.length && right + left < b.length && a[a.length - right - 1] === b[b.length - right - 1]) {
+  while (right + left < aArr.length && right + left < bArr.length && aArr[aArr.length - right - 1] === bArr[bArr.length - right - 1]) {
     right++
   }
   return {
-    index: left,
-    remove: a.length - left - right,
-    insert: b.slice(left, b.length - right)
+    index: aArr.slice(0, left).reduce((acc, c) => acc + c.length, 0),
+    remove: aArr.slice(left, aArr.length - right).reduce((acc, c) => acc + c.length, 0),
+    insert: bArr.slice(left, bArr.length - right).join('')
   }
 }
 
@@ -99,37 +101,42 @@ export const simpleDiffArray = (a, b, compare = equalityStrict) => {
  * @param {number} cursor This should refer to the current left cursor-range position
  */
 export const simpleDiffStringWithCursor = (a, b, cursor) => {
+  const aArr = Array.from(a)
+  const bArr = Array.from(b)
   let left = 0 // number of same characters counting from left
   let right = 0 // number of same characters counting from right
   // Iterate left to the right until we find a changed character
   // First iteration considers the current cursor position
   while (
-    left < a.length &&
-    left < b.length &&
-    a[left] === b[left] &&
-    left < cursor
+    left < aArr.length &&
+    left < bArr.length &&
+    aArr[left] === bArr[left]
   ) {
+    if (aArr[left].length === 2 && cursor > 0) {
+      cursor-- // Adjust cursor position for surrogate pairs
+    }
+    if (left >= cursor) break
     left++
   }
   // Iterate right to the left until we find a changed character
   while (
-    right + left < a.length &&
-    right + left < b.length &&
-    a[a.length - right - 1] === b[b.length - right - 1]
+    right + left < aArr.length &&
+    right + left < bArr.length &&
+    aArr[aArr.length - right - 1] === bArr[bArr.length - right - 1]
   ) {
     right++
   }
   // Try to iterate left further to the right without caring about the current cursor position
   while (
-    right + left < a.length &&
-    right + left < b.length &&
-    a[left] === b[left]
+    right + left < aArr.length &&
+    right + left < bArr.length &&
+    aArr[left] === bArr[left]
   ) {
     left++
   }
   return {
-    index: left,
-    remove: a.length - left - right,
-    insert: b.slice(left, b.length - right)
+    index: aArr.slice(0, left).reduce((acc, c) => acc + c.length, 0),
+    remove: aArr.slice(left, aArr.length - right).reduce((acc, c) => acc + c.length, 0),
+    insert: bArr.slice(left, bArr.length - right).join('')
   }
 }

--- a/diff.test.js
+++ b/diff.test.js
@@ -2,7 +2,6 @@ import { simpleDiffString, simpleDiffArray, simpleDiffStringWithCursor } from '.
 import * as prng from './prng.js'
 import * as f from './function.js'
 import * as t from './testing.js'
-import * as object from './object.js'
 import * as str from './string.js'
 
 /**
@@ -14,8 +13,12 @@ function runDiffTest (a, b, expected) {
   const result = simpleDiffString(a, b)
   t.compare(result, expected)
   t.compare(result, simpleDiffStringWithCursor(a, b, a.length)) // check that the withCursor approach returns the same result
-  const arrResult = simpleDiffArray(a.split(''), b.split(''))
-  t.compare(arrResult, object.assign({}, result, { insert: result.insert.split('') }))
+  const recomposed = str.splice(a, result.index, result.remove, result.insert)
+  t.compareStrings(recomposed, b)
+  const arrResult = simpleDiffArray(Array.from(a), Array.from(b))
+  const arrRecomposed = Array.from(a)
+  arrRecomposed.splice(arrResult.index, arrResult.remove, ...arrResult.insert)
+  t.compareStrings(arrRecomposed.join(''), b)
 }
 
 /**
@@ -30,6 +33,8 @@ export const testDiffing = tc => {
   runDiffTest('abc', 'xyz', { index: 0, remove: 3, insert: 'xyz' })
   runDiffTest('axz', 'au', { index: 1, remove: 2, insert: 'u' })
   runDiffTest('ax', 'axy', { index: 2, remove: 0, insert: 'y' })
+  runDiffTest('\u{d83d}\u{dc77}'/* '👷‍♀️' */, '\u{d83d}\u{dea7}\u{d83d}\u{dc77}'/* '🚧👷‍♀️' */, { index: 0, remove: 0, insert: '🚧' })
+  runDiffTest('\u{d83d}\u{dea7}\u{d83d}\u{dc77}'/* '🚧👷‍♀️' */, '\u{d83d}\u{dc77}'/* '👷‍♀️' */, { index: 0, remove: 2, insert: '' })
 }
 
 /**
@@ -73,6 +78,13 @@ export const testSimpleDiffWithCursor = tc => {
     t.compare(change, { insert: '', remove: 3, index: 5 })
     const recomposed = str.splice(initial, change.index, change.remove, change.insert)
     t.compareStrings(expected, recomposed)
+  }
+  {
+    const initial = '🚧🚧🚧'
+    const change = simpleDiffStringWithCursor(initial, '🚧🚧', 2) // Should delete after the midst of 🚧
+    t.compare(change, { insert: '', remove: 2, index: 2 })
+    const recomposed = str.splice(initial, change.index, change.remove, change.insert)
+    t.compareStrings('🚧🚧', recomposed)
   }
 }
 

--- a/diff.test.js
+++ b/diff.test.js
@@ -33,8 +33,8 @@ export const testDiffing = tc => {
   runDiffTest('abc', 'xyz', { index: 0, remove: 3, insert: 'xyz' })
   runDiffTest('axz', 'au', { index: 1, remove: 2, insert: 'u' })
   runDiffTest('ax', 'axy', { index: 2, remove: 0, insert: 'y' })
-  runDiffTest('\u{d83d}\u{dc77}'/* '👷‍♀️' */, '\u{d83d}\u{dea7}\u{d83d}\u{dc77}'/* '🚧👷‍♀️' */, { index: 0, remove: 0, insert: '🚧' })
-  runDiffTest('\u{d83d}\u{dea7}\u{d83d}\u{dc77}'/* '🚧👷‍♀️' */, '\u{d83d}\u{dc77}'/* '👷‍♀️' */, { index: 0, remove: 2, insert: '' })
+  runDiffTest('\u{d83d}\u{dc77}'/* '👷' */, '\u{d83d}\u{dea7}\u{d83d}\u{dc77}'/* '🚧👷' */, { index: 0, remove: 0, insert: '🚧' })
+  runDiffTest('\u{d83d}\u{dea7}\u{d83d}\u{dc77}'/* '🚧👷' */, '\u{d83d}\u{dc77}'/* '👷' */, { index: 0, remove: 2, insert: '' })
 }
 
 /**


### PR DESCRIPTION
fix https://github.com/yjs/yjs/issues/303

Current diff algorithm may produce invalid combinations of surrogate pair.
To avoid this, we can use `Array.from` to calculate the length and index in safe.

This changes may cause performance degradation, so we have an option to implement this in another function. IMO it is better to be able to handle surrogate pairs correctly in all situations.
