### PR TITLE
Eject encodeAny, decodeAny from buffer - fixes #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ In practice, when decoding several million small strings, the GC will kick in mo
 <b><code>encoding.RleEncoder#bufs: Array&lt;Uint8Array&gt;</code></b><br>
 <b><code>encoding.IntDiffEncoder#bufs: Array&lt;Uint8Array&gt;</code></b><br>
 <b><code>encoding.RleIntDiffEncoder#bufs: Array&lt;Uint8Array&gt;</code></b><br>
-<b><code>buffer.encodeAny(data: any): Uint8Array</code></b><br>
+<b><code>encoding.encodeAny(data: any): Uint8Array</code></b><br>
 <dd><p>Encode anything as a UInt8Array. It's a pun on typescripts's <code>any</code> type.
 See encoding.writeAny for more information.</p></dd>
 </dl>

--- a/README.md
+++ b/README.md
@@ -200,11 +200,6 @@ broadcastchannel.publish('my events', 'hello from tab B') // => A: 'hello from t
 <b><code>buffer.fromBase64</code></b><br>
 <b><code>buffer.copyUint8Array(uint8Array: Uint8Array): Uint8Array</code></b><br>
 <dd><p>Copy the content of an Uint8Array view to a new ArrayBuffer.</p></dd>
-<b><code>buffer.encodeAny(data: any): Uint8Array</code></b><br>
-<dd><p>Encode anything as a UInt8Array. It's a pun on typescripts's <code>any</code> type.
-See encoding.writeAny for more information.</p></dd>
-<b><code>buffer.decodeAny(buf: Uint8Array): any</code></b><br>
-<dd><p>Decode an any-encoded value.</p></dd>
 </dl>
 </details>
 <details><summary><b>[lib0/cache]</b> An implementation of a map which has keys that expire.</summary>
@@ -409,6 +404,8 @@ to the next byte and read it as unsigned integer.</p></dd>
 <dd><p>Decoding target.</p></dd>
 <b><code>decoding.IntDiffOptRleDecoder#pos: number</code></b><br>
 <dd><p>Current decoding position.</p></dd>
+<b><code>decoding.decodeAny(buf: Uint8Array): any</code></b><br>
+<dd><p>Decode an any-encoded value.</p></dd>
 </dl>
 </details>
 <details><summary><b>[lib0/diff]</b> Efficient diffs.</summary>
@@ -710,6 +707,9 @@ In practice, when decoding several million small strings, the GC will kick in mo
 <b><code>encoding.RleEncoder#bufs: Array&lt;Uint8Array&gt;</code></b><br>
 <b><code>encoding.IntDiffEncoder#bufs: Array&lt;Uint8Array&gt;</code></b><br>
 <b><code>encoding.RleIntDiffEncoder#bufs: Array&lt;Uint8Array&gt;</code></b><br>
+<b><code>buffer.encodeAny(data: any): Uint8Array</code></b><br>
+<dd><p>Encode anything as a UInt8Array. It's a pun on typescripts's <code>any</code> type.
+See encoding.writeAny for more information.</p></dd>
 </dl>
 </details>
 <details><summary><b>[lib0/map]</b> Isomorphic module to work access the environment (query params, env variables).</summary>

--- a/buffer.js
+++ b/buffer.js
@@ -6,8 +6,6 @@
 
 import * as string from './string.js'
 import * as env from './environment.js'
-import * as encoding from './encoding.js'
-import * as decoding from './decoding.js'
 
 /**
  * @param {number} len
@@ -92,24 +90,3 @@ export const copyUint8Array = uint8Array => {
   newBuf.set(uint8Array)
   return newBuf
 }
-
-/**
- * Encode anything as a UInt8Array. It's a pun on typescripts's `any` type.
- * See encoding.writeAny for more information.
- *
- * @param {any} data
- * @return {Uint8Array}
- */
-export const encodeAny = data => {
-  const encoder = encoding.createEncoder()
-  encoding.writeAny(encoder, data)
-  return encoding.toUint8Array(encoder)
-}
-
-/**
- * Decode an any-encoded value.
- *
- * @param {Uint8Array} buf
- * @return {any}
- */
-export const decodeAny = buf => decoding.readAny(decoding.createDecoder(buf))

--- a/buffer.test.js
+++ b/buffer.test.js
@@ -19,12 +19,3 @@ export const testRepeatBase64Encoding = tc => {
   }
   t.compare(copied, decoded)
 }
-
-/**
- * @param {t.TestCase} tc
- */
-export const testAnyEncoding = tc => {
-  const obj = { val: 1, arr: [1, 2], str: '409231dtrnä' }
-  const res = buffer.decodeAny(buffer.encodeAny(obj))
-  t.compare(obj, res)
-}

--- a/decoding.js
+++ b/decoding.js
@@ -679,3 +679,11 @@ export class StringDecoder {
     return res
   }
 }
+
+/**
+ * Decode an any-encoded value.
+ *
+ * @param {Uint8Array} buf
+ * @return {any}
+ */
+export const decodeAny = buf => readAny(createDecoder(buf))

--- a/encoding.js
+++ b/encoding.js
@@ -853,3 +853,16 @@ export class StringEncoder {
     return toUint8Array(encoder)
   }
 }
+
+/**
+ * Encode anything as a UInt8Array. It's a pun on typescripts's `any` type.
+ * See encoding.writeAny for more information.
+ *
+ * @param {any} data
+ * @return {Uint8Array}
+ */
+export const encodeAny = data => {
+  const encoder = createEncoder()
+  writeAny(encoder, data)
+  return toUint8Array(encoder)
+}

--- a/encoding.test.js
+++ b/encoding.test.js
@@ -840,3 +840,12 @@ export const testInvalidVarIntEncoding = _tc => {
     decoding.readVarUint(decoder)
   })
 }
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testAnyEncoding = tc => {
+  const obj = { val: 1, arr: [1, 2], str: '409231dtrnä' }
+  const res = decoding.decodeAny(encoding.encodeAny(obj))
+  t.compare(obj, res)
+}


### PR DESCRIPTION
Having some trouble adding playwright to my project because of circular dependencies.

![Screenshot from 2023-02-24 12-01-14](https://user-images.githubusercontent.com/23239955/221088802-38258ec3-f62f-4ce2-ae20-6df13e2e0108.png)

This PR moves the `encodeAny` and `decodeAny` methods from `buffer` to `encoding` and `decoding` respectively.

fixes #16, #19, #51