### PR TITLE
Remove unnecessary `new` from encoding / decoding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,13 +277,13 @@ Using getAsync &amp; setIfUndefined ensures that the init function is only calle
 and is compatible with Golang's binary encoding (https://golang.org/pkg/encoding/binary/)
 which is also used in Protocol Buffers.</p>
 <pre class="prettyprint source lang-js"><code>// encoding step
-const encoder = new encoding.createEncoder()
+const encoder = encoding.createEncoder()
 encoding.writeVarUint(encoder, 256)
 encoding.writeVarString(encoder, 'Hello world!')
 const buf = encoding.toUint8Array(encoder)
 </code></pre>
 <pre class="prettyprint source lang-js"><code>// decoding step
-const decoder = new decoding.createDecoder(buf)
+const decoder = decoding.createDecoder(buf)
 decoding.readVarUint(decoder) // => 256
 decoding.readVarString(decoder) // => 'Hello world!'
 decoding.hasContent(decoder) // => false - all data is read
@@ -479,13 +479,13 @@ can better optimize these function calls.</p></dd>
 and is compatible with Golang's binary encoding (https://golang.org/pkg/encoding/binary/)
 which is also used in Protocol Buffers.</p>
 <pre class="prettyprint source lang-js"><code>// encoding step
-const encoder = new encoding.createEncoder()
+const encoder = encoding.createEncoder()
 encoding.writeVarUint(encoder, 256)
 encoding.writeVarString(encoder, 'Hello world!')
 const buf = encoding.toUint8Array(encoder)
 </code></pre>
 <pre class="prettyprint source lang-js"><code>// decoding step
-const decoder = new decoding.createDecoder(buf)
+const decoder = decoding.createDecoder(buf)
 decoding.readVarUint(decoder) // => 256
 decoding.readVarString(decoder) // => 'Hello world!'
 decoding.hasContent(decoder) // => false - all data is read

--- a/decoding.js
+++ b/decoding.js
@@ -9,7 +9,7 @@
  *
  * ```js
  * // encoding step
- * const encoder = new encoding.createEncoder()
+ * const encoder = encoding.createEncoder()
  * encoding.writeVarUint(encoder, 256)
  * encoding.writeVarString(encoder, 'Hello world!')
  * const buf = encoding.toUint8Array(encoder)
@@ -17,7 +17,7 @@
  *
  * ```js
  * // decoding step
- * const decoder = new decoding.createDecoder(buf)
+ * const decoder = decoding.createDecoder(buf)
  * decoding.readVarUint(decoder) // => 256
  * decoding.readVarString(decoder) // => 'Hello world!'
  * decoding.hasContent(decoder) // => false - all data is read

--- a/encoding.js
+++ b/encoding.js
@@ -9,7 +9,7 @@
  *
  * ```js
  * // encoding step
- * const encoder = new encoding.createEncoder()
+ * const encoder = encoding.createEncoder()
  * encoding.writeVarUint(encoder, 256)
  * encoding.writeVarString(encoder, 'Hello world!')
  * const buf = encoding.toUint8Array(encoder)
@@ -17,7 +17,7 @@
  *
  * ```js
  * // decoding step
- * const decoder = new decoding.createDecoder(buf)
+ * const decoder = decoding.createDecoder(buf)
  * decoding.readVarUint(decoder) // => 256
  * decoding.readVarString(decoder) // => 'Hello world!'
  * decoding.hasContent(decoder) // => false - all data is read


### PR DESCRIPTION
Fixing some typos which must be wrong, given [the actual usage in y-websocket](https://github.com/yjs/y-websocket/blob/master/bin/utils.js#L274) and also from my tests.

Thanks for your awesome projects.