### PR TITLE
export BC from broadcastchannel

### DIFF
--- a/broadcastchannel.js
+++ b/broadcastchannel.js
@@ -66,7 +66,7 @@ class LocalStoragePolyfill {
 
 // Use BroadcastChannel or Polyfill
 /* c8 ignore next */
-const BC = typeof BroadcastChannel === 'undefined' ? LocalStoragePolyfill : BroadcastChannel
+export const BC = typeof BroadcastChannel === 'undefined' ? LocalStoragePolyfill : BroadcastChannel
 
 /**
  * @param {string} room


### PR DESCRIPTION
Want to use LocalStoragePolyfill when BroadcastChannel is unsupported in browser, but BC isn't exported.