### PR TITLE
Check localStorage is null

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -40,7 +40,7 @@ let usePolyfill = true
 /* c8 ignore start */
 try {
   // if the same-origin rule is violated, accessing localStorage might thrown an error
-  if (typeof localStorage !== 'undefined') {
+  if (typeof localStorage !== 'undefined' && localStorage !== null) {
     _localStorage = localStorage
     usePolyfill = false
   }


### PR DESCRIPTION
It appears that in its default state, Android WebView does not support LocalStorage. When attempting to read "window.localStorage", it returns "null".
This issue is causing some difficulties as it is not only necessary to check if "window.localStorage" is undefined, but also if it is null. This additional check is required due to the default behavior of Android WebView.