### PR TITLE
Fix references to nonexistent files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,9 +75,9 @@
     "./conditions.js": "./conditions.js",
     "./dist/conditions.cjs": "./dist/conditions.cjs",
     "./conditions": {
-      "types": "./condititons.d.ts",
-      "module": "./condititons.js",
-      "import": "./condititons.js",
+      "types": "./conditions.d.ts",
+      "module": "./conditions.js",
+      "import": "./conditions.js",
       "require": "./dist/conditions.cjs"
     },
     "./crypto/jwt": {


### PR DESCRIPTION
This PR fixes references to the files `"./conditions.d.ts"` and `"./conditions.js"`, so that they're more properly exported by this package.