### PR TITLE
[delta] failing test for diff with asymmetric top-level delete

### DIFF
--- a/src/delta/delta.test.js
+++ b/src/delta/delta.test.js
@@ -1160,3 +1160,18 @@ export const testRepeatRandomXmlDeltaApply = tc => {
 export const testRepeatRandomXmlDeltaApplyLarge = tc => {
   testDeltaApply(tc, $xmlDelta, { minChildOps: 50, maxChildOps: 80 })
 }
+
+export const testDiffAsymmetricTopLevelDelete = () => {
+  const d1 = /** @type {delta.DeltaAny} */ (delta.create().insert([delta.create('paragraph').insert('hello')]).delete(1).done())
+  const d2 = /** @type {delta.DeltaAny} */ (delta.create().insert([delta.create('paragraph').insert('world')]).done())
+  // Forward: inner content updates to match d2; d1's asymmetric top-level delete is preserved.
+  t.compare(
+    delta.clone(d1).apply(delta.diff(d1, d2)),
+    delta.create().insert([delta.create('paragraph').insert('world')]).delete(1)
+  )
+  // Reverse: inner content updates; d1's delete can't be forward-represented and is dropped.
+  t.compare(
+    delta.clone(d2).apply(delta.diff(d2, d1)),
+    delta.create().insert([delta.create('paragraph').insert('hello')])
+  )
+}


### PR DESCRIPTION
Hey Kevin, here is a diff test that was failing. I needed this to test something, so I had an AI just generate a fix, I won't commit it, but here it is:

## AI suggested fix

In `diff()`, the middle-range walks (cs1/cs2 builders and the formatting walk) only handled text/insert ops and threw `error.unexpectedCase()` when a `delete` op appeared on only one side. The AI's fix treats asymmetric delete ops as state-content-irrelevant and skips past them:

```diff
--- a/src/delta/delta.js
+++ b/src/delta/delta.js
@@ -2363,9 +2363,14 @@ export const diff = (d1, d2) => {
      * @type {Array<fingerprintTrait.Fingerprintable>}
      */
     const cs2 = []
-    // if right is null, then we already matched everything
+    // if right is null, then we already matched everything. Asymmetric delete ops
+    // (present on one side but not the other) don't contribute state content; skip them.
     if (right1 != null) {
       while (left1 !== null && left1 !== right1.next) {
+        if ($deleteOp.check(left1)) {
+          left1 = left1.next
+          continue
+        }
         if ($textOp.check(left1)) {
           cs1.push(left1.insert)
         } else if ($insertOp.check(left1)) {
@@ -2379,6 +2384,10 @@ export const diff = (d1, d2) => {
     }
     if (right2 != null) {
       while (left2 !== null && left2 !== right2.next) {
+        if ($deleteOp.check(left2)) {
+          left2 = left2.next
+          continue
+        }
         if ($textOp.check(left2)) {
           cs2.push(left2.insert)
         } else if ($insertOp.check(left2)) {
@@ -2408,47 +2417,51 @@ export const diff = (d1, d2) => {
       const originalUpdated = clone(d1)
       originalUpdated.apply(/** @type {DeltaAny} */ (d))
       let bOffset = 0
-      // update a to match b
-      let a = /** @type {InsertOp<any>|TextOp|null} */ (originalUpdated.children.start)
-      let b = /** @type {InsertOp<any>|TextOp|null} */ (d2.children.start)
+      // update a to match b; skip delete ops since they don't consume content position
+      let a = /** @type {InsertOp<any>|TextOp|DeleteOp<any>|null} */ (originalUpdated.children.start)
+      let b = /** @type {InsertOp<any>|TextOp|DeleteOp<any>|null} */ (d2.children.start)
       let aOffset = 0
       while (a != null && b != null) {
-        if (!$deleteOp.check(b) && !$deleteOp.check(a)) {
-          const aFormat = a.format
-          ...normal case...
-          if (bOffset >= b.length) { b = b.next; bOffset = 0 }
-          if (aOffset >= a.length) { a = a.next; aOffset = 0 }
-        } else {
-          error.unexpectedCase()
+        if ($deleteOp.check(a)) { a = a.next; continue }
+        if ($deleteOp.check(b)) { b = b.next; continue }
+        const aFormat = a.format
+        ...normal case...
+        if (bOffset >= b.length) { b = b.next; bOffset = 0 }
+        if (aOffset >= a.length) { a = a.next; aOffset = 0 }
         }
       }
```

Note: the fix is lossy — `diff(d1, d2).apply(d1) == d2` only holds in the direction where d2 has no unrepresentable deletes; the other direction drops d1's delete since a forward diff can't undo it.