### PR TITLE
fix: switch `isBrowser` to Buffer existance check

### DIFF
--- a/src/buffer.js
+++ b/src/buffer.js
@@ -5,7 +5,6 @@
  */
 
 import * as string from './string.js'
-import * as env from './environment.js'
 import * as array from './array.js'
 import * as math from './math.js'
 import * as encoding from './encoding.js'
@@ -88,10 +87,10 @@ const fromBase64Node = s => {
 }
 
 /* c8 ignore next */
-export const toBase64 = /* @__PURE__ */(() => env.isBrowser ? toBase64Browser : toBase64Node)()
+export const toBase64 = /* @__PURE__ */(() => typeof Buffer === 'undefined' ? toBase64Browser : toBase64Node)()
 
 /* c8 ignore next */
-export const fromBase64 = /* @__PURE__ */(() => env.isBrowser ? fromBase64Browser : fromBase64Node)()
+export const fromBase64 = /* @__PURE__ */(() => typeof Buffer === 'undefined' ? fromBase64Browser : fromBase64Node)()
 
 /**
  * Implements base64url - see https://datatracker.ietf.org/doc/html/rfc4648#section-5


### PR DESCRIPTION
I was trying to use the base64 encode & decode utilities within a WebWorker, which does not have access to the `window` or `document` global variables. I thought that a better check for these was actually to guard on the existance of a Buffer function.

This should work in more runtimes (e.g. Deno & Bun), while also being slightly more correct.
