### PR TITLE
fix: tolerate unavailable browser environment storage

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -95,12 +95,18 @@ export const getParam = (name, defaultVal) => computeParams().get(name) || defau
  * @param {string} name
  * @return {string|null}
  */
-/* c8 ignore next 5 */
 /* @__NO_SIDE_EFFECTS__ */
-export const getVariable = (name) =>
-  isNode
-    ? conditions.undefinedToNull(process.env[name.toUpperCase().replaceAll('-', '_')])
-    : conditions.undefinedToNull(storage.varStorage.getItem(name))
+export const getVariable = (name) => {
+  if (isNode) {
+    return conditions.undefinedToNull(process.env[name.toUpperCase().replaceAll('-', '_')])
+  }
+  try {
+    return conditions.undefinedToNull(storage.varStorage.getItem(name))
+  } catch (e) {
+    // Storage reads can fail even when accessing the localStorage object succeeds.
+    return null
+  }
+}
 
 /**
  * @param {string} name

--- a/src/environment.test.js
+++ b/src/environment.test.js
@@ -1,0 +1,87 @@
+import * as t from './testing.js'
+import * as env from './environment.js'
+
+/**
+ * Use a fresh process so browser globals are in place before environment/storage are imported,
+ * without changing the test runner's globals or reusing its already evaluated modules.
+ *
+ * @param {string} script
+ */
+const runInBrowserEnvironment = script => {
+  const { execFileSync } = process.getBuiltinModule('child_process')
+  execFileSync(process.execPath, ['--input-type=module', '--eval', `
+    import assert from 'node:assert/strict'
+    globalThis.window = {}
+    globalThis.document = {}
+    globalThis.process = undefined
+    const environmentURL = ${JSON.stringify(new URL('./environment.js', import.meta.url).href)}
+    ${script}
+  `], { encoding: 'utf8' })
+}
+
+/**
+ * @param {t.TestCase} _tc
+ */
+export const testBrowserStorageReadFailureDuringImport = _tc => {
+  t.skip(!env.isNode || env.isDeno)
+  for (const name of ['NS_ERROR_FAILURE', 'SecurityError']) {
+    runInBrowserEnvironment(`
+      globalThis.localStorage = {
+        getItem () { throw new DOMException('Failure', ${JSON.stringify(name)}) }
+      }
+      const environment = await import(environmentURL)
+      assert.equal(environment.production, false)
+      assert.equal(environment.getVariable('missing'), null)
+      assert.equal(environment.hasConf('missing'), false)
+    `)
+  }
+}
+
+/**
+ * @param {t.TestCase} _tc
+ */
+export const testBrowserStorageReadRecovery = _tc => {
+  t.skip(!env.isNode || env.isDeno)
+  runInBrowserEnvironment(`
+    const values = new Map([['production', ''], ['custom', 'configured']])
+    let unavailable = false
+    globalThis.localStorage = {
+      getItem (name) {
+        if (unavailable) throw new DOMException('Failure', 'NS_ERROR_FAILURE')
+        return values.get(name)
+      }
+    }
+    const environment = await import(environmentURL)
+    assert.equal(environment.production, true)
+    assert.equal(environment.getVariable('production'), '')
+    assert.equal(environment.getVariable('custom'), 'configured')
+    assert.equal(environment.getVariable('missing'), null)
+    unavailable = true
+    assert.equal(environment.getVariable('custom'), null)
+    unavailable = false
+    assert.equal(environment.getVariable('custom'), 'configured')
+  `)
+}
+
+/**
+ * @param {t.TestCase} _tc
+ */
+export const testNodeEnvironmentVariable = _tc => {
+  t.skip(!env.isNode || env.isDeno)
+  const name = 'LIB0_ENVIRONMENT_TEST'
+  const previous = process.env[name]
+  try {
+    process.env[name] = 'configured'
+    t.compare(env.getVariable('lib0-environment-test'), 'configured')
+    process.env[name] = ''
+    t.compare(env.getVariable('lib0-environment-test'), '')
+    delete process.env[name]
+    t.compare(env.getVariable('lib0-environment-test'), null)
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = previous
+    }
+  }
+}

--- a/src/test.js
+++ b/src/test.js
@@ -9,6 +9,7 @@ import * as sha256 from './hash/sha256.test.js'
 import * as logging from './logging.test.js'
 import * as string from './string.test.js'
 import * as encoding from './encoding.test.js'
+import * as environment from './environment.test.js'
 import * as diff from './diff.test.js'
 import * as patienceDiff from './diff/patience.test.js'
 import * as testing from './testing.test.js'
@@ -67,6 +68,7 @@ runTests({
   logging,
   string,
   encoding,
+  environment,
   diff,
   patienceDiff,
   testing,


### PR DESCRIPTION
Fixes #131.

When a browser exposes `localStorage` but `getItem()` throws, the top-level environment flag checks can prevent `lib0/environment` from loading. Catch browser storage read failures in `getVariable()` and return `null`, matching a missing flag. The Node environment-variable path is unchanged, and later successful storage reads still work.

Adds tests to the existing runner for import-time `NS_ERROR_FAILURE`/`SecurityError`, readable and missing values, temporary storage failure followed by recovery, and Node variable normalization. Browser initialization is exercised in isolated Node subprocesses with browser globals set before importing the real modules. The new failure tests fail against the previous implementation.

The production report was on 0.2.117; this PR targets the current ESM-only `main` branch.

Validation:
- `node src/test.js --filter 'environment:'`
- `npm test` (including coverage thresholds)
- `npm run lint` (JSDoc types, Standard style, circular imports)
